### PR TITLE
Fix duplicate move collision

### DIFF
--- a/dupes.py
+++ b/dupes.py
@@ -1,6 +1,5 @@
 import os
 import hashlib
-from PIL import Image
 from shutil import move
 from tqdm import tqdm
 
@@ -18,7 +17,9 @@ def find_duplicate_images(directory):
     duplicates = []
 
     image_files = []
-    for root, _, files in os.walk(directory):
+    for root, dirs, files in os.walk(directory):
+        if 'dupes' in dirs:
+            dirs.remove('dupes')
         for file in files:
             if file.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.bmp')):
                 image_files.append(os.path.join(root, file))
@@ -33,6 +34,16 @@ def find_duplicate_images(directory):
 
     return duplicates
 
+def move_with_unique_name(src, dest_dir):
+    base = os.path.basename(src)
+    name, ext = os.path.splitext(base)
+    dest_path = os.path.join(dest_dir, base)
+    counter = 1
+    while os.path.exists(dest_path):
+        dest_path = os.path.join(dest_dir, f"{name}_{counter}{ext}")
+        counter += 1
+    move(src, dest_path)
+
 def main():
     directory = os.getcwd()
     create_directory_if_not_exists(os.path.join(directory, "dupes"))
@@ -41,7 +52,7 @@ def main():
     
     for duplicate_image, original_image in duplicate_images:
         print(f"Found duplicate: {duplicate_image} (Original: {original_image})")
-        move(duplicate_image, os.path.join(directory, "dupes", os.path.basename(duplicate_image)))
+        move_with_unique_name(duplicate_image, os.path.join(directory, "dupes"))
 
     print("Finished processing all files.")
 


### PR DESCRIPTION
## Summary
- skip the `dupes` directory when searching for images
- create a `move_with_unique_name` helper to prevent collisions when moving files
- remove unused Image import

## Testing
- `python -m py_compile dupes.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa77cb13483269eef04cea09d390b